### PR TITLE
upgrade babel-eslint

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -17,7 +17,7 @@
   "homepage": "https://github.com/ueno-llc/styleguide#readme",
   "dependencies": {
     "@ueno/eslint-plugin-internal": "1.0.5",
-    "babel-eslint": "8.0.1",
+    "babel-eslint": "^10.0.3",
     "eslint-config-airbnb": "16.0.0",
     "eslint-config-airbnb-base": "12.1.0",
     "eslint-import-resolver-webpack": "0.8.3",


### PR DESCRIPTION
Upgrade babel eslint to support JSX fragment shorthand `<></>`